### PR TITLE
JhonsonX experiment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ find_package(Boost)
 
 
 add_executable(dijkstraX dijkstraX.cpp)
+add_executable(jhonsonX jhonsonX.cpp)
+
+add_executable(grid_graph_example GridWithRoughBoundaries.cpp grid_graph_example.cpp)
 
 add_executable(GridWithRoughBoundaries_test GridWithRoughBoundaries.cpp GridWithRoughBoundaries_test.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.17)
+project(Dijkstra_grid)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wfatal-errors -Wall -pedantic")
+
+find_package(Boost)
+
+
+
+add_executable(dijkstraX dijkstraX.cpp)
+
+add_executable(GridWithRoughBoundaries_test GridWithRoughBoundaries.cpp GridWithRoughBoundaries_test.cpp)
+
+add_executable(makeGrid GridWithRoughBoundaries.cpp makeGrid.cpp)

--- a/GridWithRoughBoundaries.cpp
+++ b/GridWithRoughBoundaries.cpp
@@ -1,0 +1,146 @@
+#include <optional>
+#include <string>
+#include <sstream>
+#include <exception>
+#include "GridWithRoughBoundaries.h"
+
+using namespace std::string_literals;
+
+
+std::ostream& operator<<(std::ostream& os, const Vertex& v)
+{
+    os<<"Vertex{"s<<std::to_string(v.row)<<","s<<std::to_string(v.col)<<"}"s;
+    return os;
+}
+
+int detail::compute_num_edges(int side_nodes_count)
+{
+    return (side_nodes_count-1)*side_nodes_count
+         + (side_nodes_count-1)*(side_nodes_count-2);
+}
+
+
+/**
+ * Get the position of an edge in storage according to the position on the grid.
+ * 0,0   0,1   0,2   0,3
+ *  |     |     |     |
+ * 1,0 - 1,1 - 1,2 - 1,3
+ *  |     |     |     |
+ * 2,0 - 2,1 - 2,2 - 2,3
+ *  |     |     |     |
+ * 3,0   3,1   3,2   3,3
+ */
+
+
+bool detail::are_grid_neighbours(Vertex s, Vertex t)
+{
+    return (s.row-t.row)*(s.col-t.col) == 0
+           and std::abs(s.row-t.row) + std::abs(s.col-t.col) == 1;
+}
+
+
+bool detail::are_vertical_boundary_nodes(int side_node_count, Vertex s, Vertex t)
+{
+    return (s.row==0 and t.row==0) or (s.row==side_node_count-1 and t.row==side_node_count-1);
+}
+
+
+
+std::optional<int> detail::get_storage_index_for_weight(int side_node_count, Vertex s, Vertex t)
+{
+    using namespace detail;
+
+     Vertex first{std::min(s.row,t.row),std::min(s.col,t.col)};
+     Vertex second{std::max(s.row,t.row),std::max(s.col,t.col)};
+
+     if(!are_grid_neighbours(s,t) || are_vertical_boundary_nodes(side_node_count,s,t))
+         return std::nullopt;
+
+     if(first.col == second.col) // Vertical case:
+     {
+         // 0,0   0,1   0,2   0,3
+         //  |     |     |     |
+         // 1,0   1,1   1,2   1,3
+         //  |     |     |     |
+         // 2,0   2,1   2,2   2,3
+         //  |     |     |     |
+         // 3,0   3,1   3,2   3,3
+         return (side_node_count-1)*first.col + first.row;
+     }
+     else if (first.row == second.row) // Horizontal case
+     {
+         // 0,0   0,1   0,2   0,3
+         //
+         // 1,0 - 1,1 - 1,2 - 1,3
+         //
+         // 2,0 - 2,1 - 2,2 - 2,3
+         //
+         // 3,0   3,1   3,2   3,3
+         int horizontal_node_offset = (side_node_count-1)*side_node_count;
+         return horizontal_node_offset + (first.row-1)*(side_node_count-1) + first.col;
+     }
+
+    return std::nullopt;
+}
+
+
+
+void GridWithRoughBoundaries::traverse_edges(const std::function<void(Vertex,Vertex)>& f) const
+{
+    for (int col = 0; col < side_length_; ++col)
+        for (int row = 0; row < side_length_-1; ++row)
+            f(Vertex{row, col}, Vertex{row+1, col});
+
+    for (int row = 1; row < side_length_-1; ++row)
+        for (int col = 0; col < side_length_ - 1; ++col)
+            f(Vertex{row, col}, Vertex{row, col+1});
+
+
+}
+
+void GridWithRoughBoundaries::traverse_nodes(const std::function<void(Vertex)>& f) const
+{
+    for (int col = 0; col < side_length_; ++col)
+        for (int row = 0; row < side_length_; ++row)
+            f(Vertex{row, col});
+}
+
+
+
+GridWithRoughBoundaries::GridWithRoughBoundaries(int side_nodes_count)
+: side_length_(side_nodes_count), weights_(detail::compute_num_edges(side_nodes_count),0.0)
+{}
+
+
+double GridWithRoughBoundaries::edge_weight(const Vertex& s, const Vertex& t) const {
+    auto maybe_idx = detail::get_storage_index_for_weight(side_length_,s,t);
+    if(maybe_idx) return weights_.at(*maybe_idx);
+    return std::numeric_limits<double>::infinity();
+}
+
+void GridWithRoughBoundaries::edge_weight(const Vertex& s, const Vertex& t, double new_value) {
+    auto maybe_idx = detail::get_storage_index_for_weight(side_length_,s,t);
+    if(maybe_idx)
+    {
+        weights_.at(*maybe_idx) = new_value;
+        return;
+    }
+    std::ostringstream ss("");
+    ss<<"Nodes not neighbours of grid: "<<s<<" and "<<t;
+    throw std::runtime_error(ss.str());
+}
+
+
+int GridWithRoughBoundaries::label(const Vertex& s) const {
+    return s.row*side_length_ + s.col;
+}
+
+Vertex GridWithRoughBoundaries::vertex_from_label(int l) const {
+    return Vertex{static_cast<int>(l/this->nodes_per_side()), static_cast<int>(l%this->nodes_per_side())};
+}
+
+
+int GridWithRoughBoundaries::num_edges() const
+{
+    return detail::compute_num_edges(nodes_per_side());
+}

--- a/GridWithRoughBoundaries.h
+++ b/GridWithRoughBoundaries.h
@@ -1,0 +1,61 @@
+#ifndef DIJKSTRA_GRID_GRIDWITHROUGHBOUNDARIES_H
+#define DIJKSTRA_GRID_GRIDWITHROUGHBOUNDARIES_H
+
+#include <vector>
+#include <ostream>
+#include <optional>
+#include <functional>
+
+// 0,0   0,1   0,2   0,3
+//  |     |     |     |
+// 1,0 - 1,1 - 1,2 - 1,3
+//  |     |     |     |
+// 2,0 - 2,1 - 2,2 - 2,3
+//  |     |     |     |
+// 3,0   3,1   3,2   3,3
+
+
+struct Vertex
+{
+    int row;
+    int col;
+};
+
+std::ostream& operator<<(std::ostream& os, const Vertex& v);
+
+class GridWithRoughBoundaries {
+public:
+    explicit GridWithRoughBoundaries(int side_nodes_count);
+
+
+    double edge_weight(const Vertex& s, const Vertex& t) const;
+    void edge_weight(const Vertex& s, const Vertex& t, double new_value);
+
+    /// Get a unique label for each vertex
+    int label(const Vertex& s) const;
+    Vertex vertex_from_label(int l) const;
+
+    void traverse_nodes(const std::function<void(Vertex)>& f) const;
+    void traverse_edges(const std::function<void(Vertex,Vertex)>& f) const;
+
+    int nodes_per_side() const {return side_length_;}
+    int num_edges() const;
+
+private:
+    const int side_length_;
+    std::vector<double> weights_;
+};
+
+
+
+namespace detail
+{
+    bool are_grid_neighbours(Vertex s, Vertex t);
+    std::optional<int> get_storage_index_for_weight(int side_node_count, Vertex s, Vertex t);
+    bool are_vertical_boundary_nodes(int side_node_count, Vertex s, Vertex t);
+    int compute_num_edges(int side_nodes_count);
+
+}
+
+
+#endif //DIJKSTRA_GRID_GRIDWITHROUGHBOUNDARIES_H

--- a/GridWithRoughBoundaries_test.cpp
+++ b/GridWithRoughBoundaries_test.cpp
@@ -1,0 +1,49 @@
+#include "GridWithRoughBoundaries.h"
+#include <cassert>
+#include <cstring>
+#include <iostream>
+
+int main()
+{
+
+    // 0,0   0,1   0,2   0,3
+    //  |     |     |     |
+    // 1,0 - 1,1 - 1,2 - 1,3
+    //  |     |     |     |
+    // 2,0 - 2,1 - 2,2 - 2,3
+    //  |     |     |     |
+    // 3,0   3,1   3,2   3,3
+
+
+    const size_t k_gsize = 7;
+    GridWithRoughBoundaries g(k_gsize);
+
+    try {
+        g.edge_weight({0,0},{0,1},1);
+    }
+    catch(std::exception& e)
+    {
+        assert(strcmp("Nodes not neighbours of grid: Vertex{0,0} and Vertex{0,1}",e.what())==0);
+    }
+
+
+
+
+    int counter = 0;
+    g.traverse_edges([&](Vertex s, Vertex t){
+//      std::cout << s << t
+//                << *detail::get_storage_index_for_weight(k_gsize, s, t)
+//                << std::endl;
+      g.edge_weight(s, t, counter++);
+    });
+
+
+    counter = 0;
+    g.traverse_edges([&](Vertex s, Vertex t){
+        assert(*detail::get_storage_index_for_weight(k_gsize, s, t)==counter);
+        assert((g.edge_weight(s,t)==counter++));
+    });
+
+
+    return 0;
+}

--- a/benchmark.py
+++ b/benchmark.py
@@ -5,24 +5,40 @@ from typing import *
 
 
 slow_values = list(map(lambda x: x*100,range(1,11)))
-fast_values = list(map(lambda x: x*10,range(1,11)))
+fast_values = [2,3,4,5,10,15,20,30]
 
 values = fast_values
 
 
 if __name__ == "__main__":
 
-    data : List[float] = []
+    dijsktra_results : List[float] = []
+    jhonson_results : List[float] = []
 
 
     for v in values:
-        os.system("./cmake-build-debug/makeGrid %i %i testGraph.txt testSource.txt"%(v,v/10))
-        start = datetime.datetime.now()
-        os.system("./cmake-build-debug/dijkstraX -e testGraph.txt -s testSource.txt -w testOut.txt")
-        finish = datetime.datetime.now()
-        tdiff = finish-start
-        print(v, tdiff, tdiff.total_seconds())
-        data.append(tdiff.total_seconds())
+        # Make a grid graph
+        os.system("./cmake-build-debug/makeGrid %i %i testGraph.txt testSource.txt"%(v,v/2))
 
-    plt.plot(values, data)
+        # Benchmark against dijkstraX
+        start = datetime.datetime.now()
+        os.system("./cmake-build-debug/dijkstraX -e testGraph.txt -s testSource.txt -w testOut_dijkstra.txt")
+        finish = datetime.datetime.now()
+        dijkstra_tdiff = finish - start
+
+        # Run JhonsonX
+        start = datetime.datetime.now()
+        os.system("./cmake-build-debug/jhonsonX -e testGraph.txt -s testSource.txt -w testOut_jhonson.txt")
+        finish = datetime.datetime.now()
+        jhonson_tdiff = finish - start
+
+        print(v, dijkstra_tdiff, jhonson_tdiff)
+        dijsktra_results.append(dijkstra_tdiff.total_seconds())
+        jhonson_results.append(jhonson_tdiff.total_seconds())
+
+    l1,l2 = plt.plot(values, dijsktra_results, values, jhonson_results)
+    plt.title("Shortest path finding, 50% source nodes")
+    plt.ylabel("Time in seconds")
+    plt.xlabel("Code distance")
+    plt.legend((l1,l2),("Dijkstra's running time", "Jhonson's Running time"))
     plt.show()

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,28 @@
+import os
+import datetime
+import matplotlib.pyplot as plt
+from typing import *
+
+
+slow_values = list(map(lambda x: x*100,range(1,11)))
+fast_values = list(map(lambda x: x*10,range(1,11)))
+
+values = fast_values
+
+
+if __name__ == "__main__":
+
+    data : List[float] = []
+
+
+    for v in values:
+        os.system("./cmake-build-debug/makeGrid %i %i testGraph.txt testSource.txt"%(v,v/10))
+        start = datetime.datetime.now()
+        os.system("./cmake-build-debug/dijkstraX -e testGraph.txt -s testSource.txt -w testOut.txt")
+        finish = datetime.datetime.now()
+        tdiff = finish-start
+        print(v, tdiff, tdiff.total_seconds())
+        data.append(tdiff.total_seconds())
+
+    plt.plot(values, data)
+    plt.show()

--- a/jhonsonX.cpp
+++ b/jhonsonX.cpp
@@ -10,10 +10,11 @@
 #include <boost/config.hpp>
 #include <iostream>
 #include <fstream>
+#include <vector>
 
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/graph/johnson_all_pairs_shortest.hpp>
 #include <boost/property_map/property_map.hpp>
 
 #include <typeinfo>
@@ -236,15 +237,15 @@ int main(int argc, char* argv[])
     int* sb_pairs_weight = new int[source_num];
     int closest_b, closest_b_weight;
 
-    // Main Dijkstra algorithm starts below, where single-source-all-pair dijkstra is looped over all sources.
-    // We are only interested in the edge weights between the sources.
+    // First compute all to all paths with Jhonson's, then extract only distances from sources to sources
+    std::vector<std::vector<int>> output_distance_matrix (num_vertices(g),std::vector<int>(num_vertices(g),0));
+    boost::johnson_all_pairs_shortest_paths(g, output_distance_matrix);
+
     for (ii=0; ii<source_num; ii++)
     {
 
-        std::vector< int > d(num_vertices(g));
         vertex_descriptor s = vertex(sources[ii], g);
-
-        dijkstra_shortest_paths(g, s,distance_map(&d[0]));
+        const std::vector<int>& d = output_distance_matrix[s];
 
         // After the dijkstra for source s, all distances to s is saved in d.
         // The following loop find the distance from s to other source nodes, save them to dijkstra_weights.

--- a/jhonsonX.cpp
+++ b/jhonsonX.cpp
@@ -1,0 +1,303 @@
+//=======================================================================
+// Copyright 2001 Jeremy G. Siek, Andrew Lumsdaine, Lie-Quan Lee,
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//=======================================================================
+#include <stdio.h>
+
+#include <boost/config.hpp>
+#include <iostream>
+#include <fstream>
+
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/property_map/property_map.hpp>
+
+#include <typeinfo>
+
+using namespace boost;
+
+void LoadFile(int& node_num, int& edge_num, int*& edges_flat, int*& weights, char* filename)
+{
+    int e = 0;
+    char LINE[1000];
+    FILE* fp = fopen(filename, "r");
+    if (!fp) { printf("Can't open %s\n", filename); exit(1); }
+
+    int format = -1; // 0: DIMACS format. node id's start from 1
+                     // 1: simpler format (without "p" and "e"). node id's start from 0
+
+    edge_num = -1;
+    while (fgets(LINE, sizeof(LINE)-1, fp))
+    {
+        if (LINE[0] == 'c') continue;
+        if (format < 0)
+        {
+            if (LINE[0] == 'p')
+            {
+                format = 0;
+                if (sscanf(LINE, "p edge %d %d\n", &node_num, &edge_num) != 2) { printf("%s: wrong format #1\n", filename); exit(1); }
+            }
+            else
+            {
+                format = 1;
+                if (sscanf(LINE, "%d %d\n", &node_num, &edge_num) != 2) { printf("%s: wrong format #1\n", filename); exit(1); }
+            }
+
+            //////////////////////////////////////////////////////////////////////////////////
+            if (node_num <= 0 || edge_num < 0) { printf("# of nodes and edges_flat should be positive\n"); exit(1); }
+            edges_flat = new int[2*edge_num];
+            weights = new int[edge_num];
+            //////////////////////////////////////////////////////////////////////////////////
+        }
+        else
+        {
+            int i, j;
+            char* ptr = LINE;
+            if (format == 0) { if (LINE[0] != 'e') continue; ptr = &LINE[1]; }
+            else             ptr = &LINE[0];
+
+            int len;
+            if (sscanf(ptr, "%d %d %d\n", &i, &j, &len) != 3) continue;
+            if (format == 0) { i --; j --; }
+            edges_flat[2*e] = i;
+            edges_flat[2*e+1] = j;
+            weights[e] = len;
+            e ++;
+        }
+    }
+
+    if (e != edge_num) { printf("%s: wrong format #3\n", filename); exit(1); }
+    fclose(fp);
+}
+
+void LoadSourceInfo(int& source_num, int& boundary_num, int*& sources, int*& boundaries, char* filename)
+{
+    int e = 0;
+    char LINE[1000];
+    int* all_list;
+    FILE* fp = fopen(filename, "r");
+    if (!fp) { printf("Can't open %s\n", filename); exit(1); }
+
+    int format = -1; // 0: DIMACS format. node id's start from 1
+                     // 1: simpler format (without "p" and "e"). node id's start from 0
+
+    source_num = -1;
+    while (fgets(LINE, sizeof(LINE)-1, fp))
+    {
+        if (LINE[0] == 'c') continue;
+        if (format < 0)
+        {
+            // The first row of the source file record the source_num and boundary_num
+            if (LINE[0] == 'p')
+            {
+                format = 0;
+                if (sscanf(LINE, "p edge %d %d\n", &source_num, &boundary_num) != 2) { printf("%s: wrong format #1\n", filename); exit(1); }
+            }
+            else
+            {
+                format = 1;
+                if (sscanf(LINE, "%d %d\n", &source_num, &boundary_num) != 2) { printf("%s: wrong format #1\n", filename); exit(1); }
+            }
+
+            //////////////////////////////////////////////////////////////////////////////////
+            if (source_num <= 0 || boundary_num < 0) { printf("# of nodes and edges_flat should be positive\n"); exit(1); }
+            sources = new int[source_num];
+            boundaries = new int[boundary_num];
+            all_list = new int[source_num + boundary_num];
+            //////////////////////////////////////////////////////////////////////////////////
+        }
+        else
+        {
+            int i,j;
+            char* ptr = LINE;
+            if (format == 0) { if (LINE[0] != 'e') continue; ptr = &LINE[1]; }
+            else             ptr = &LINE[0];
+
+            if (sscanf(ptr, "%d\n", &i) != 1) continue;
+            if (format == 0) { i --; j --; }
+            all_list[e] = i;
+            e ++;
+        }
+    }
+
+    if (e != (source_num + boundary_num)) { printf("%s: wrong format #3\n", filename); exit(1); }
+    fclose(fp);
+
+    // Although source nodes and boundary nodes are both in the Source file, they are loaded to separate variables: sources and boundaries
+    // For the dijkstra, we are interested in:
+    // 1. the distance between all source nodes
+    // 2. the distance between every source node and its closest boundary node
+
+    for (int j=0;j<source_num;j++) sources[j] = all_list[j];
+    for (int j=0;j<boundary_num;j++) boundaries[j] = all_list[source_num+j];
+    delete [] all_list;
+
+}
+
+void SaveDijkstra(int source_num, int pair_num, int* pairs_flat, int* dijkstra_weights, int* sb_pairs_flat, int* sb_pairs_weight, char* filename)
+{
+    FILE* fp = fopen(filename, "w");
+    if (!fp) { printf("Can't open %s\n", filename); exit(1); }
+    fprintf(fp, "%d %d\n", source_num*2, pair_num+source_num);
+    int i;
+    for (i=0; i<pair_num; i++)
+    {
+        fprintf(fp, "%d %d %d\n", pairs_flat[2*i], pairs_flat[2*i+1], dijkstra_weights[i]);
+    }
+    for (i=0; i<source_num; i++)
+    {
+        fprintf(fp, "%d %d %d\n", sb_pairs_flat[2*i], sb_pairs_flat[2*i+1], sb_pairs_weight[i]);
+    }
+    fclose(fp);
+}
+
+void ShowUsage()
+{
+    printf("Something went wrong\n");
+    exit(1);
+}
+
+
+int main(int argc, char* argv[])
+{
+
+    typedef adjacency_list< listS, vecS, undirectedS, no_property,
+        property< edge_weight_t, int > >
+        graph_t;
+    typedef graph_traits< graph_t >::vertex_descriptor vertex_descriptor;
+    typedef std::pair< int, int > Edge;
+
+    char* filename = NULL;
+    char* save_filename = NULL;
+    char* source_info_filename = NULL;
+
+
+    int i, e, node_num, edge_num, source_num, boundary_num;
+    int* edges_flat;
+    int* weights;
+    int* sources;
+    int* boundaries;
+
+    for (i=1; i<argc; i++)
+    {
+        if (argv[i][0] != '-') { printf("Unknown option: %s\n", argv[i]); ShowUsage(); }
+        switch (argv[i][1])
+        {
+            case 'e':
+                if (filename || argv[i][2] || ++i == argc) ShowUsage();
+                filename = argv[i];
+                break;
+            case 's':
+                if (source_info_filename || argv[i][2] || ++i == argc) ShowUsage();
+                source_info_filename = argv[i];
+                break;
+            case 'w':
+                if (save_filename || argv[i][2] || ++i == argc) ShowUsage();
+                save_filename = argv[i];
+                break;
+            default:
+                printf("Unknown option: %s\n", argv[i]);
+                ShowUsage();
+                break;
+        }
+        
+    }
+
+    if (!filename) ShowUsage();
+
+    if (filename) LoadFile(node_num, edge_num, edges_flat, weights, filename);
+
+    if (source_info_filename) LoadSourceInfo(source_num, boundary_num, sources, boundaries, source_info_filename);
+
+
+    Edge edge_array[edge_num];
+
+    for (e=0; e<edge_num; e++) edge_array[e] = Edge(edges_flat[2*e], edges_flat[2*e+1]);
+    graph_t g(edge_array, edge_array + edge_num, weights, node_num);
+
+    int ii, jj, pair_num = 0, pp = 0;
+
+    for (int kk=1; kk<source_num; kk++) pair_num = pair_num + kk;
+
+    // int pairs_flat[2*pair_num]; 
+    int* pairs_flat = new int[2*pair_num];
+
+    // int dijkstra_weights[pair_num]; 
+    int* dijkstra_weights = new int[pair_num];
+    
+    // int sb_pairs_flat[2*source_num];
+    int* sb_pairs_flat = new int[2*source_num];
+
+    // int sb_pairs_weight[source_num];
+    int* sb_pairs_weight = new int[source_num];
+    int closest_b, closest_b_weight;
+
+    // Main Dijkstra algorithm starts below, where single-source-all-pair dijkstra is looped over all sources.
+    // We are only interested in the edge weights between the sources.
+    for (ii=0; ii<source_num; ii++)
+    {
+
+        std::vector< int > d(num_vertices(g));
+        vertex_descriptor s = vertex(sources[ii], g);
+
+        dijkstra_shortest_paths(g, s,distance_map(&d[0]));
+
+        // After the dijkstra for source s, all distances to s is saved in d.
+        // The following loop find the distance from s to other source nodes, save them to dijkstra_weights.
+        for (jj=1; jj<(source_num-ii); jj++)
+        {
+            pairs_flat[2*pp] = sources[ii];
+            pairs_flat[2*pp+1] = sources[ii+jj];
+
+            dijkstra_weights[pp] = d[sources[ii+jj]];
+
+            pp++;
+            // std::cout << "pp is: " << pp << std::endl;
+
+        }
+
+        // The following loop is to find the closest boundadry node for each source.
+        closest_b = boundaries[0];
+        closest_b_weight = d[closest_b];
+        for (int bb=1;bb<boundary_num; bb++){
+            if (d[boundaries[bb]]<closest_b_weight) {
+                closest_b = boundaries[bb];
+                closest_b_weight = d[closest_b];
+            }
+
+        }
+
+        sb_pairs_flat[2*ii] = sources[ii];
+        sb_pairs_flat[2*ii+1] = closest_b;
+        sb_pairs_weight[ii] = closest_b_weight;
+
+    }
+
+    
+    if (save_filename) SaveDijkstra(source_num, pair_num, pairs_flat, dijkstra_weights, sb_pairs_flat, sb_pairs_weight, save_filename);
+
+
+
+    if (filename)
+    {
+        delete [] edges_flat;
+        delete [] weights;
+    }
+
+    if (source_info_filename)
+    {
+        delete [] sources;
+        delete [] boundaries;
+    }
+
+    delete [] pairs_flat;
+    delete [] dijkstra_weights;
+    delete [] sb_pairs_flat;
+    delete [] sb_pairs_weight;
+
+    return EXIT_SUCCESS;
+}

--- a/makeGrid.cpp
+++ b/makeGrid.cpp
@@ -1,0 +1,80 @@
+#include "GridWithRoughBoundaries.h"
+
+#include <iostream>
+#include <optional>
+#include <cstdlib>
+#include <random>
+#include <fstream>
+#include <ranges>
+
+template<class T>
+using delayed = std::optional<T>;
+
+
+const std::string k_usage = "Usage: makeGrid <nodes per side> <num source nodes> <GRAPH in file> <SOURCE in file>\n";
+
+struct edge_weights{
+  static constexpr int k_max = 1000000;
+  static constexpr int k_min = 1;
+};
+
+
+int main(int argc, char* argv[])
+{
+
+    if(argc!=5)
+    {
+        std::cerr<<k_usage;
+        return EXIT_FAILURE;
+    }
+
+    int nodes_per_side = std::stoi(argv[1]);
+    int num_source_nodes = std::stoi(argv[2]);
+    std::string graph_in_fname{argv[3]};
+    std::string source_in_fname{argv[4]};
+
+    GridWithRoughBoundaries g{nodes_per_side};
+
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<int> edge_weight_distribution(edge_weights::k_min,edge_weights::k_max);
+
+    {
+        std::ofstream graph_in_file(graph_in_fname);
+        graph_in_file << g.nodes_per_side()*g.nodes_per_side() << " " << g.num_edges() << std::endl;
+
+        g.traverse_edges([&](Vertex s, Vertex t)
+        {
+          graph_in_file << g.label(s) << " " << g.label(t) << " " << edge_weight_distribution(rng) << std::endl;
+        });
+    }
+
+    {
+        std::ofstream source_in_file(source_in_fname);
+        source_in_file << num_source_nodes << " " << g.nodes_per_side()*2 << std::endl;
+
+        std::vector<unsigned int> indices(g.nodes_per_side()*g.nodes_per_side());
+        std::iota(indices.begin(), indices.end(), 0);
+        std::shuffle(indices.begin(), indices.end(), std::mt19937(std::random_device()()));
+
+
+        auto is_boundary = [&g](const Vertex& v) -> bool
+        {
+            return v.row ==0 and v.row == g.nodes_per_side()-1;
+        };
+
+        for (int i = 0; i<num_source_nodes; ++i)
+        {
+            while(is_boundary(g.vertex_from_label(indices[i]))) i++;
+            source_in_file << indices[i] << std::endl;
+        }
+
+        for (int i = 0; i<g.nodes_per_side(); ++i)
+        {
+            source_in_file << g.label(Vertex{0,i}) << std::endl;
+            source_in_file << g.label(Vertex{g.nodes_per_side()-1,i}) << std::endl;
+        }
+
+    }
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Tried switching to boost's implementation of jhonson's algorithm for finding shortest paths. Also adds a class to generate weighted grids with rough boundaries.

Results weren't great:
![Screenshot_20210321_032046](https://user-images.githubusercontent.com/36427091/111901282-6e456800-89f4-11eb-8d2d-53957992b152.png)
It turns out that under the hood Jhonson's just runs Dijkstra's even more times (it runs it on all pairs).

https://github.com/boostorg/graph/blob/e4e12158e78157397254505f6cbae688e3e3174f/include/boost/graph/johnson_all_pairs_shortest.hpp#L124-L137

Further it runs an unnecessary iteration of Bellman Ford to check for negative cycles.


